### PR TITLE
Add upstreamed patches which backport support for registers for CPLD PNs

### DIFF
--- a/patch/0064-platform-mellanox-mlxreg-io-Fix-read-access-of-n-byt.patch
+++ b/patch/0064-platform-mellanox-mlxreg-io-Fix-read-access-of-n-byt.patch
@@ -1,0 +1,32 @@
+From 288281c9d0867821b711079baeb8af4024fc1fb8 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Tue, 6 Jul 2021 05:57:39 +0000
+Subject: [PATCH 07/80] platform/mellanox: mlxreg-io: Fix read access of
+ n-bytes size attributes
+
+Fix shift argument for function rol32(). It should be provided in bits,
+while was provided in bytes.
+
+Fixes: 86148190a7db: (" platform/mellanox: mlxreg-io: Add support for complex attributes")
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/mellanox/mlxreg-io.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-io.c b/drivers/platform/mellanox/mlxreg-io.c
+index 6b82f5e..772a8a3 100644
+--- a/drivers/platform/mellanox/mlxreg-io.c
++++ b/drivers/platform/mellanox/mlxreg-io.c
+@@ -102,9 +102,8 @@ mlxreg_io_get_reg(void *regmap, struct mlxreg_core_data *data, u32 in_val,
+ 			if (ret)
+ 				goto access_error;
+ 
+-			*regval |= rol32(val, regsize * i);
++			*regval |= rol32(val, regsize * i * 8);
+ 		}
+-		*regval = le32_to_cpu(*regval & regmax);
+ 	}
+ 
+ access_error:
+-- 
+2.8.4

--- a/patch/0144-platform-x86-mlx-platform-Fix-cpld-_pn-register-seco.patch
+++ b/patch/0144-platform-x86-mlx-platform-Fix-cpld-_pn-register-seco.patch
@@ -1,0 +1,60 @@
+From e14ffe4cfe1e63be1aa2fbec7d95637ed6fd18a3 Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Thu, 14 Oct 2021 06:46:43 +0000
+Subject: [PATCH] platform/x86: mlx-platform: Fix cpld*_pn register second byte
+ reading
+
+When we are reading register which is 2 bytes length we checking both bytes
+for volatile/readable ability. We using a 2-byte type for reading CPLD{N}_PN
+value. This fix adds a second (CPLD{N}_PN+1) register to the volatile/read
+check function.
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 149a2e9e9..997e75fb6 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -27,7 +27,11 @@
+ #define MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET	0x02
+ #define MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET	0x03
+ #define MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET	0x04
++#define MLXPLAT_CPLD_LPC_REG_CPLD1_PN1_OFFSET	0x05
+ #define MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET	0x06
++#define MLXPLAT_CPLD_LPC_REG_CPLD2_PN1_OFFSET	0x07
+ #define MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET	0x08
++#define MLXPLAT_CPLD_LPC_REG_CPLD3_PN1_OFFSET	0x09
+ #define MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET	0x0a
++#define MLXPLAT_CPLD_LPC_REG_CPLD4_PN1_OFFSET	0x0b
+ #define MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET	0x1d
+@@ -4395,7 +4399,11 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD3_PN1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
+@@ -4524,7 +4532,11 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD3_PN1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
+-- 
+2.20.1
+

--- a/patch/series
+++ b/patch/series
@@ -83,6 +83,8 @@ net-sch_generic-fix-the-missing-new-qdisc-assignment.patch
 0030-hwmon-Add-convience-macro-to-define-simple-static-se.patch
 0031-backport-nvme-Add-hardware-monitoring-support.patch
 0032-platform-mellanox-mlxreg-hotplug-Use-capability-regi.patch
+0064-platform-mellanox-mlxreg-io-Fix-read-access-of-n-byt.patch
+0144-platform-x86-mlx-platform-Fix-cpld-_pn-register-seco.patch
 
 # Cisco patches for 4.19 kernel
 cisco-ds4424-null-of-node.patch


### PR DESCRIPTION
These patches are being back-ported from the linux mainline in order to fix a bug where all bytes of CPLD registers are not being fully read by the kernel on Mellanox platforms in 4.19

See table below for upstream commits
| Patch                                                           | Upstream                                                                        | 
|-----------------------------------------------------------------|---------------------------------------------------------------------------------|
| 0064-platform-mellanox-mlxreg-io-Fix-read-access-of-n-byt.patch | https://github.com/gregkh/linux/commit/5fd56f11838da1580cc77743c08cf02c9cd48380 | 
| 0144-platform-x86-mlx-platform-Fix-cpld-_pn-register-seco.patch | https://github.com/gregkh/linux/commit/9045512ca6cdb221cd1ed32d483eac3c30c53bed | 